### PR TITLE
caesarcrypto.py

### DIFF
--- a/Cryptography/Caesar/caesarcrypto.py
+++ b/Cryptography/Caesar/caesarcrypto.py
@@ -1,6 +1,6 @@
-alphabet = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
-
+import string
+alphabet=list(string.ascii_lowercase)
+alphalen=len(alphabet)
 
 def encrypt(input, key):
     plaintext = ''
@@ -8,11 +8,10 @@ def encrypt(input, key):
         if x is not ' ':
             plaintext += x
     ciphertext = ''
+            
     for x in plaintext:
         if x in alphabet:
-            step = alphabet.index(x)+key
-            if step > 25:
-                step -= 26
+            step = (alphabet.index(x)+key)%alphalen
             ciphertext += alphabet[step]
         else:
             ciphertext += x
@@ -22,12 +21,10 @@ def encrypt(input, key):
 def decrypt(cipher, key):
     plaintext = ''
     for x in cipher:
-        step = alphabet.index(x)-key
-        if step < 0:
-            step += 26
+        step = (alphabet.index(x)-key)%alphalen
         plaintext += alphabet[step]
     return plaintext
 
-text = encrypt('my name is chef', 3)
-text2 = decrypt(text, 3)
-print "%s \n%s" % (text, text2)
+text = encrypt('my name is chef', 150)
+text2 = decrypt(text, 150)
+print ("%s \n%s" % (text, text2))


### PR DESCRIPTION


```
# Description

Instead of subtracting or adding 26 from/to the step, what is not working for big values of key parameter we calculate step modulo lenght of alphabet. We can also use string package to get the alphabet.

Fixes # (issue)
we can enter larger key parameter values
## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
```
